### PR TITLE
fix link for fabric8 console

### DIFF
--- a/add-ons/fabric8/fabric8.addon
+++ b/add-ons/fabric8/fabric8.addon
@@ -34,4 +34,4 @@ echo Or you can watch in the OpenShift console via:
 echo   minishift console
 echo -
 echo Then you should be able the open the fabric8 console here:
-echo   https://fabric8-fabric8.#{routing-suffix}/
+echo   http://fabric8-fabric8.#{routing-suffix}/


### PR DESCRIPTION
Fabric8 console is running only on HTTP